### PR TITLE
Attempt to preserve the existing trap DEBUG command.

### DIFF
--- a/share/chruby/auto.sh
+++ b/share/chruby/auto.sh
@@ -27,5 +27,10 @@ if [[ -n "$ZSH_VERSION" ]]; then
 		preexec_functions+=("chruby_auto")
 	fi
 elif [[ -n "$BASH_VERSION" ]]; then
-	trap '[[ "$BASH_COMMAND" != "$PROMPT_COMMAND" ]] && chruby_auto' DEBUG
+	cmd='[[ "$BASH_COMMAND" != "$PROMPT_COMMAND" ]] && chruby_auto'
+	hook="$(trap -p DEBUG)"
+	hook="${hook:13:-7}"
+	hook="${hook}${hook:+; }${cmd}"
+	trap "$hook" DEBUG
+	unset cmd hook
 fi


### PR DESCRIPTION
* Unfortunately, the DEBUG and RETURN traps are not inherited by sourced
  scripts, so `trap -p DEBUG` always returns an empty string.
  We would have to enable trap inheritance with `set -T`, source auto.sh,
  then disable it with `set +T`.chruby